### PR TITLE
Remove license classifier from pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,6 @@ license-files = ["LICENSE"]
 keywords = ["egg", "bacon", "sausage", "tomatoes", "Lobster Thermidor"]
 classifiers = [
     "Programming Language :: Python :: 3",
-    "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
 ]
 


### PR DESCRIPTION
## What?
Removes the license classifier (`License :: OSI Approved :: MIT License`) line from the package's `pyproject.toml`.
## Why?
License classifiers are not only deprecated, but they also raise an error when setuptools tries to build the package, rendering it unusable in other projects. The error is shown below.

```
setuptools.errors.InvalidConfigError: License classifiers have been superseded by license expressions (see https://peps.python.org/pep-0639/). Please remove:

License :: OSI Approved :: MIT License
```
## How?
I removed one line from the `pyproject.toml`.
## Testing?
The package is now installable via this branch's most recent commit.
## Anything Else?
Have a nice day.