### PR TITLE
Fix incompatible foreign key types

### DIFF
--- a/carpi_data_model/models.py
+++ b/carpi_data_model/models.py
@@ -4,7 +4,7 @@ from sqlalchemy.orm import DeclarativeBase, declarative_base
 
 Base: DeclarativeBase = declarative_base()
 
-_RELATIONSHIP_ENUM = ["COREQ", "CROSS"]
+_RELATIONSHIP_TYPE_ENUM = ["COREQ", "CROSS"]
 _RESTRICTION_RULE_ENUM = ["MUST_BE", "CANNOT_BE"]
 _RESTRICTION_TYPE_ENUM = [
     "MAJOR",
@@ -18,7 +18,9 @@ _RESTRICTION_TYPE_ENUM = [
 ]
 _SEMESTER_ENUM = ["FALL", "SPRING", "SUMMER"]
 
-RELATIONSHIP_ENUM = Enum(*_RELATIONSHIP_ENUM, name="relationship", native_enum=True)
+RELATIONSHIP_TYPE_ENUM = Enum(
+    *_RELATIONSHIP_TYPE_ENUM, name="relationship_type", native_enum=True
+)
 RESTRICTION_RULE_ENUM = Enum(
     *_RESTRICTION_RULE_ENUM, name="restriction_rule", native_enum=True
 )
@@ -88,7 +90,7 @@ class Course_Relationship(Base):
 
     subj_code = Column(VARCHAR(4), primary_key=True)
     code_num = Column(VARCHAR(4), primary_key=True)
-    relationship = Column(RELATIONSHIP_ENUM, nullable=False)
+    relationship = Column(RELATIONSHIP_TYPE_ENUM, nullable=False)
     rel_subj = Column(VARCHAR(4), primary_key=True)
     rel_code_num = Column(VARCHAR(4), primary_key=True)
 


### PR DESCRIPTION
## What?
Fixes a critical issue in which the `category` and `restr_code` foreign keys had a type mismatch with the referenced keys. This pull request also adds some minor enhancements including unifying the `Enum` objects used in column types and adding a type hint to the `Base` object.
## Why?
Previously, SQLAlchemy would crash when trying to create tables from this schema definition as the schema was illegal.
## How?
I ensured foreign key types matched the type of the referenced keys.
## Testing?
I was able to create tables just fine.
## Anything Else?
Have a nice day.