### PR TITLE
Refactor models to use SQLAlchemy 2.0 typing API

### DIFF
--- a/carpi_data_model/models.py
+++ b/carpi_data_model/models.py
@@ -1,12 +1,11 @@
 from enum import Enum as PyEnum
 
-from sqlalchemy import Column
 from sqlalchemy import Enum as SQLEnum
 from sqlalchemy import ForeignKey, ForeignKeyConstraint
 from sqlalchemy.dialects.mysql import SMALLINT, TEXT, TINYINT, VARCHAR
-from sqlalchemy.orm import DeclarativeBase, declarative_base
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
 
-Base: DeclarativeBase = declarative_base()
+Base = DeclarativeBase()
 
 
 class RelationshipTypeEnum(str, PyEnum):
@@ -51,50 +50,56 @@ SEMESTER_ENUM = SQLEnum(SemesterEnum, name="semester", native_enum=True)
 class Subject(Base):
     __tablename__ = "subject"
 
-    subj_code = Column(VARCHAR(4), primary_key=True)
-    title = Column(VARCHAR(255), nullable=False)
+    subj_code: Mapped[str] = mapped_column(VARCHAR(4), primary_key=True)
+    title: Mapped[str] = mapped_column(VARCHAR(255), nullable=False)
 
 
 class Attribute(Base):
     __tablename__ = "attribute"
 
-    attr_code = Column(VARCHAR(4), primary_key=True)
-    title = Column(VARCHAR(255), nullable=False)
+    attr_code: Mapped[str] = mapped_column(VARCHAR(4), primary_key=True)
+    title: Mapped[str] = mapped_column(VARCHAR(255), nullable=False)
 
 
 class Restriction(Base):
     __tablename__ = "restriction"
 
-    category = Column(RESTRICTION_TYPE_ENUM, primary_key=True)
-    restr_code = Column(VARCHAR(20), primary_key=True)
-    title = Column(VARCHAR(255), nullable=False)
+    category: Mapped[RestrictionTypeEnum] = mapped_column(
+        RESTRICTION_TYPE_ENUM, primary_key=True
+    )
+    restr_code: Mapped[str] = mapped_column(VARCHAR(20), primary_key=True)
+    title: Mapped[str] = mapped_column(VARCHAR(255), nullable=False)
 
 
 class Faculty(Base):
     __tablename__ = "faculty"
 
-    rcsid = Column(VARCHAR(15), primary_key=True)
-    first_name = Column(VARCHAR(255), nullable=False)
-    last_name = Column(VARCHAR(255), nullable=False)
+    rcsid: Mapped[str] = mapped_column(VARCHAR(15), primary_key=True)
+    first_name: Mapped[str] = mapped_column(VARCHAR(255), nullable=False)
+    last_name: Mapped[str] = mapped_column(VARCHAR(255), nullable=False)
 
 
 class Course(Base):
     __tablename__ = "course"
 
-    subj_code = Column(VARCHAR(4), ForeignKey("subject.subj_code"), primary_key=True)
-    code_num = Column(VARCHAR(4), primary_key=True)
-    title = Column(VARCHAR(255), nullable=False)
-    desc_text = Column(TEXT, nullable=False)
-    credit_min = Column(TINYINT, nullable=False)
-    credit_max = Column(TINYINT, nullable=False)
+    subj_code: Mapped[str] = mapped_column(
+        VARCHAR(4), ForeignKey("subject.subj_code"), primary_key=True
+    )
+    code_num: Mapped[str] = mapped_column(VARCHAR(4), primary_key=True)
+    title: Mapped[str] = mapped_column(VARCHAR(255), nullable=False)
+    desc_text: Mapped[str] = mapped_column(TEXT, nullable=False)
+    credit_min: Mapped[int] = mapped_column(TINYINT, nullable=False)
+    credit_max: Mapped[int] = mapped_column(TINYINT, nullable=False)
 
 
 class Course_Attribute(Base):
     __tablename__ = "course_attribute"
 
-    subj_code = Column(VARCHAR(4), primary_key=True)
-    code_num = Column(VARCHAR(4), primary_key=True)
-    attr_code = Column(VARCHAR(4), ForeignKey("attribute.attr_code"), primary_key=True)
+    subj_code: Mapped[str] = mapped_column(VARCHAR(4), primary_key=True)
+    code_num: Mapped[str] = mapped_column(VARCHAR(4), primary_key=True)
+    attr_code: Mapped[str] = mapped_column(
+        VARCHAR(4), ForeignKey("attribute.attr_code"), primary_key=True
+    )
 
     __table_args__ = (
         ForeignKeyConstraint(
@@ -106,11 +111,13 @@ class Course_Attribute(Base):
 class Course_Relationship(Base):
     __tablename__ = "course_relationship"
 
-    subj_code = Column(VARCHAR(4), primary_key=True)
-    code_num = Column(VARCHAR(4), primary_key=True)
-    relationship = Column(RELATIONSHIP_TYPE_ENUM, nullable=False)
-    rel_subj = Column(VARCHAR(4), primary_key=True)
-    rel_code_num = Column(VARCHAR(4), primary_key=True)
+    subj_code: Mapped[str] = mapped_column(VARCHAR(4), primary_key=True)
+    code_num: Mapped[str] = mapped_column(VARCHAR(4), primary_key=True)
+    relationship: Mapped[RelationshipTypeEnum] = mapped_column(
+        RELATIONSHIP_TYPE_ENUM, nullable=False
+    )
+    rel_subj: Mapped[str] = mapped_column(VARCHAR(4), primary_key=True)
+    rel_code_num: Mapped[str] = mapped_column(VARCHAR(4), primary_key=True)
 
     __table_args__ = (
         ForeignKeyConstraint(
@@ -125,11 +132,15 @@ class Course_Relationship(Base):
 class Course_Restriction(Base):
     __tablename__ = "course_restriction"
 
-    subj_code = Column(VARCHAR(4), primary_key=True)
-    code_num = Column(VARCHAR(4), primary_key=True)
-    restr_rule = Column(RESTRICTION_RULE_ENUM, nullable=False)
-    category = Column(RESTRICTION_TYPE_ENUM, primary_key=True)
-    restr_code = Column(VARCHAR(20), primary_key=True)
+    subj_code: Mapped[str] = mapped_column(VARCHAR(4), primary_key=True)
+    code_num: Mapped[str] = mapped_column(VARCHAR(4), primary_key=True)
+    restr_rule: Mapped[RestrictionRuleEnum] = mapped_column(
+        RESTRICTION_RULE_ENUM, nullable=False
+    )
+    category: Mapped[RestrictionTypeEnum] = mapped_column(
+        RESTRICTION_TYPE_ENUM, primary_key=True
+    )
+    restr_code: Mapped[str] = mapped_column(VARCHAR(20), primary_key=True)
 
     __table_args__ = (
         ForeignKeyConstraint(
@@ -145,12 +156,12 @@ class Course_Restriction(Base):
 class Course_Offering(Base):
     __tablename__ = "course_offering"
 
-    sem_year = Column(SMALLINT, primary_key=True)
-    semester = Column(SEMESTER_ENUM, primary_key=True)
-    subj_code = Column(VARCHAR(4), primary_key=True)
-    code_num = Column(VARCHAR(4), primary_key=True)
-    seats_filled = Column(TINYINT, nullable=False)
-    seats_total = Column(TINYINT, nullable=False)
+    sem_year: Mapped[int] = mapped_column(SMALLINT, primary_key=True)
+    semester: Mapped[SemesterEnum] = mapped_column(SEMESTER_ENUM, primary_key=True)
+    subj_code: Mapped[str] = mapped_column(VARCHAR(4), primary_key=True)
+    code_num: Mapped[str] = mapped_column(VARCHAR(4), primary_key=True)
+    seats_filled: Mapped[int] = mapped_column(TINYINT, nullable=False)
+    seats_total: Mapped[int] = mapped_column(TINYINT, nullable=False)
 
     __table_args__ = (
         ForeignKeyConstraint(
@@ -162,11 +173,13 @@ class Course_Offering(Base):
 class Course_Faculty(Base):
     __tablename__ = "course_faculty"
 
-    sem_year = Column(SMALLINT, primary_key=True)
-    semester = Column(SEMESTER_ENUM, primary_key=True)
-    subj_code = Column(VARCHAR(4), primary_key=True)
-    code_num = Column(VARCHAR(4), primary_key=True)
-    rcsid = Column(VARCHAR(15), ForeignKey("faculty.rcsid"), primary_key=True)
+    sem_year: Mapped[int] = mapped_column(SMALLINT, primary_key=True)
+    semester: Mapped[SemesterEnum] = mapped_column(SEMESTER_ENUM, primary_key=True)
+    subj_code: Mapped[str] = mapped_column(VARCHAR(4), primary_key=True)
+    code_num: Mapped[str] = mapped_column(VARCHAR(4), primary_key=True)
+    rcsid: Mapped[str] = mapped_column(
+        VARCHAR(15), ForeignKey("faculty.rcsid"), primary_key=True
+    )
 
     __table_args__ = (
         ForeignKeyConstraint(

--- a/carpi_data_model/models.py
+++ b/carpi_data_model/models.py
@@ -5,7 +5,9 @@ from sqlalchemy import ForeignKey, ForeignKeyConstraint
 from sqlalchemy.dialects.mysql import SMALLINT, TEXT, TINYINT, VARCHAR
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
 
-Base = DeclarativeBase()
+
+class Base(DeclarativeBase):
+    pass
 
 
 class RelationshipTypeEnum(str, PyEnum):

--- a/carpi_data_model/models.py
+++ b/carpi_data_model/models.py
@@ -162,8 +162,8 @@ class Course_Offering(Base):
     semester: Mapped[SemesterEnum] = mapped_column(SEMESTER_ENUM, primary_key=True)
     subj_code: Mapped[str] = mapped_column(VARCHAR(4), primary_key=True)
     code_num: Mapped[str] = mapped_column(VARCHAR(4), primary_key=True)
-    seats_filled: Mapped[int] = mapped_column(TINYINT, nullable=False)
-    seats_total: Mapped[int] = mapped_column(TINYINT, nullable=False)
+    seats_filled: Mapped[int] = mapped_column(SMALLINT, nullable=False)
+    seats_total: Mapped[int] = mapped_column(SMALLINT, nullable=False)
 
     __table_args__ = (
         ForeignKeyConstraint(


### PR DESCRIPTION
## What?

This pull request modernizes typing annotations for the CARPI data models and introduces a change in data type from TINYINT to SMALLINT for seat data.

Yes Jack, these are two changes in one pull request. I was too lazy to make another branch to fix the data type issue.

Closes #3.

## Why?

For the seat data type change, it was breaking our database as many courses have capacities that well exceed the TINYINT limit of 255. As for the typing annotation refactor, I thought it would give linters more context on column types when working with data models from other files. Turns out this is not the case, but it at least makes the distinction between Python types and SQL types more explicit.

## How?

I replaced the older SQLAlchemy 1.x style Column objects with mapped_column objects and introduced Python type hinting to database colums.

## Testing?

The data models work without issue when using it in the SIS scraper's JSON to SQL conversion script.

## Anything Else?

Have a nice day.