### PR TITLE
Create prerequisite table models

### DIFF
--- a/carpi_data_model/models.py
+++ b/carpi_data_model/models.py
@@ -241,7 +241,7 @@ class Prerequisite_Course(Base):
     og_code_num: Mapped[str] = mapped_column(VARCHAR(4), primary_key=True)
     parent_id: Mapped[int] = mapped_column(SMALLINT, primary_key=True)
     new_subj_code: Mapped[str] = mapped_column(VARCHAR(4), primary_key=True)
-    new_code_num: Mapped[int] = mapped_column(VARCHAR(4), primary_key=True)
+    new_code_num: Mapped[str] = mapped_column(VARCHAR(4), primary_key=True)
 
     __table_args__ = (
         ForeignKeyConstraint(

--- a/carpi_data_model/models.py
+++ b/carpi_data_model/models.py
@@ -239,7 +239,14 @@ class Prerequisite_Course(Base):
         ForeignKeyConstraint(
             ["og_subj_code", "og_code_num"], ["course.subj_code", "course.code_num"]
         ),
-        ForeignKeyConstraint(["parent_id"], ["prerequisite_nesting.id"]),
+        ForeignKeyConstraint(
+            ["og_subj_code", "og_code_num", "parent_id"],
+            [
+                "prerequisite_nesting.og_subj_code",
+                "prerequisite_nesting.og_code_num",
+                "prerequisite_nesting.id",
+            ],
+        ),
         ForeignKeyConstraint(
             ["new_subj_code", "new_code_num"], ["course.subj_code", "course.code_num"]
         ),

--- a/carpi_data_model/models.py
+++ b/carpi_data_model/models.py
@@ -37,6 +37,11 @@ class SemesterEnum(str, PyEnum):
     SUMMER = "SUMMER"
 
 
+class PrerequisiteNestingTypeEnum(str, PyEnum):
+    AND = "AND"
+    OR = "OR"
+
+
 RELATIONSHIP_TYPE_ENUM = SQLEnum(
     RelationshipTypeEnum, name="relationship_type", native_enum=True
 )
@@ -47,6 +52,11 @@ RESTRICTION_TYPE_ENUM = SQLEnum(
     RestrictionTypeEnum, name="restriction_type", native_enum=True
 )
 SEMESTER_ENUM = SQLEnum(SemesterEnum, name="semester", native_enum=True)
+PREREQUISITE_NESTING_TYPE_ENUM = SQLEnum(
+    PrerequisiteNestingTypeEnum,
+    name="prerequisite_nesting_type",
+    native_enum=True,
+)
 
 
 class Subject(Base):
@@ -192,5 +202,45 @@ class Course_Faculty(Base):
                 "course_offering.subj_code",
                 "course_offering.code_num",
             ],
+        ),
+    )
+
+
+class Prerequisite_Nesting(Base):
+    __tablename__ = "prerequisite_nesting"
+
+    og_subj_code: Mapped[str] = mapped_column(VARCHAR(4), primary_key=True)
+    og_code_num: Mapped[str] = mapped_column(VARCHAR(4), primary_key=True)
+    id: Mapped[int] = mapped_column(SMALLINT, primary_key=True)
+    relationship: Mapped[PrerequisiteNestingTypeEnum] = mapped_column(
+        PREREQUISITE_NESTING_TYPE_ENUM,
+        nullable=True,
+    )
+    parent_id: Mapped[int] = mapped_column(SMALLINT, nullable=True)
+
+    __table_args__ = (
+        ForeignKeyConstraint(
+            ["og_subj_code", "og_code_num"],
+            ["course.subj_code", "course.code_num"],
+        ),
+    )
+
+
+class Prerequisite_Course(Base):
+    __tablename__ = "prerequisite_course"
+
+    og_subj_code: Mapped[str] = mapped_column(VARCHAR(4), primary_key=True)
+    og_code_num: Mapped[str] = mapped_column(VARCHAR(4), primary_key=True)
+    parent_id: Mapped[int] = mapped_column(SMALLINT, primary_key=True)
+    new_subj_code: Mapped[str] = mapped_column(VARCHAR(4), primary_key=True)
+    new_code_num: Mapped[int] = mapped_column(SMALLINT, primary_key=True)
+
+    __table_args__ = (
+        ForeignKeyConstraint(
+            ["og_subj_code", "og_code_num"], ["course.subj_code", "course.code_num"]
+        ),
+        ForeignKeyConstraint(["parent_id"], ["prerequisite_nesting.id"]),
+        ForeignKeyConstraint(
+            ["new_subj_code, new_code_num"], ["course.subj_code", "course.code_num"]
         ),
     )

--- a/carpi_data_model/models.py
+++ b/carpi_data_model/models.py
@@ -245,9 +245,6 @@ class Prerequisite_Course(Base):
 
     __table_args__ = (
         ForeignKeyConstraint(
-            ["og_subj_code", "og_code_num"], ["course.subj_code", "course.code_num"]
-        ),
-        ForeignKeyConstraint(
             ["og_subj_code", "og_code_num", "parent_id"],
             [
                 "prerequisite_nesting.og_subj_code",

--- a/carpi_data_model/models.py
+++ b/carpi_data_model/models.py
@@ -233,7 +233,7 @@ class Prerequisite_Course(Base):
     og_code_num: Mapped[str] = mapped_column(VARCHAR(4), primary_key=True)
     parent_id: Mapped[int] = mapped_column(SMALLINT, primary_key=True)
     new_subj_code: Mapped[str] = mapped_column(VARCHAR(4), primary_key=True)
-    new_code_num: Mapped[int] = mapped_column(SMALLINT, primary_key=True)
+    new_code_num: Mapped[int] = mapped_column(VARCHAR(4), primary_key=True)
 
     __table_args__ = (
         ForeignKeyConstraint(

--- a/carpi_data_model/models.py
+++ b/carpi_data_model/models.py
@@ -212,11 +212,11 @@ class Prerequisite_Nesting(Base):
     og_subj_code: Mapped[str] = mapped_column(VARCHAR(4), primary_key=True)
     og_code_num: Mapped[str] = mapped_column(VARCHAR(4), primary_key=True)
     id: Mapped[int] = mapped_column(SMALLINT, primary_key=True)
-    relationship: Mapped[PrerequisiteNestingTypeEnum] = mapped_column(
+    relationship: Mapped[PrerequisiteNestingTypeEnum | None] = mapped_column(
         PREREQUISITE_NESTING_TYPE_ENUM,
         nullable=True,
     )
-    parent_id: Mapped[int] = mapped_column(SMALLINT, nullable=True)
+    parent_id: Mapped[int | None] = mapped_column(SMALLINT, nullable=True)
 
     __table_args__ = (
         ForeignKeyConstraint(

--- a/carpi_data_model/models.py
+++ b/carpi_data_model/models.py
@@ -223,6 +223,14 @@ class Prerequisite_Nesting(Base):
             ["og_subj_code", "og_code_num"],
             ["course.subj_code", "course.code_num"],
         ),
+        ForeignKeyConstraint(
+            ["og_subj_code", "og_code_num", "parent_id"],
+            [
+                "prerequisite_nesting.og_subj_code",
+                "prerequisite_nesting.og_code_num",
+                "prerequisite_nesting.id",
+            ],
+        ),
     )
 
 

--- a/carpi_data_model/models.py
+++ b/carpi_data_model/models.py
@@ -241,6 +241,6 @@ class Prerequisite_Course(Base):
         ),
         ForeignKeyConstraint(["parent_id"], ["prerequisite_nesting.id"]),
         ForeignKeyConstraint(
-            ["new_subj_code, new_code_num"], ["course.subj_code", "course.code_num"]
+            ["new_subj_code", "new_code_num"], ["course.subj_code", "course.code_num"]
         ),
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,6 @@ description = "The MySQL database schema used in Project CARPI."
 readme = "README.md"
 license = "MIT"
 license-files = ["LICENSE"]
-keywords = ["egg", "bacon", "sausage", "tomatoes", "Lobster Thermidor"]
 classifiers = [
     "Programming Language :: Python :: 3",
     "Operating System :: OS Independent",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,11 @@ name = "carpi-data-model"
 version = "1.0"
 dependencies = ["SQLAlchemy>=2.0.0"]
 requires-python = ">=3.7"
-authors = [{ name = "Raymond Chen" }, { name = "Jack Zgombic" }]
+authors = [
+    { name = "Raymond Chen" },
+    { name = "Jack Zgombic" },
+    { name = "Nick Wang" },
+]
 maintainers = [{ name = "Raymond Chen" }]
 description = "The MySQL database schema used in Project CARPI."
 readme = "README.md"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,8 @@
+-e git+https://github.com/Project-CARPI/database-schema.git#egg=carpi_data_model
+iniconfig==2.3.0
+packaging==26.0
+pluggy==1.6.0
+Pygments==2.20.0
+pytest==9.0.3
 SQLAlchemy==2.0.44
 typing_extensions==4.15.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,2 @@
--e git+https://github.com/Project-CARPI/database-schema.git#egg=carpi_data_model
-iniconfig==2.3.0
-packaging==26.0
-pluggy==1.6.0
-Pygments==2.20.0
-pytest==9.0.3
 SQLAlchemy==2.0.44
 typing_extensions==4.15.0

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -13,6 +13,8 @@ from carpi_data_model.models import (
     Course_Relationship,
     Course_Restriction,
     Faculty,
+    Prerequisite_Course,
+    Prerequisite_Nesting,
     Restriction,
     Subject,
 )
@@ -50,7 +52,7 @@ def test_create_tables(engine):
     errors. Ensures the tables actually exist in the database catalog.
     """
     inspector = inspect(engine)
-    existing_tables = inspector.get_table_names()
+    existing_tables = set(inspector.get_table_names())
 
     assert Subject.__tablename__ in existing_tables
     assert Attribute.__tablename__ in existing_tables
@@ -62,6 +64,8 @@ def test_create_tables(engine):
     assert Course_Restriction.__tablename__ in existing_tables
     assert Course_Offering.__tablename__ in existing_tables
     assert Course_Faculty.__tablename__ in existing_tables
+    assert Prerequisite_Nesting.__tablename__ in existing_tables
+    assert Prerequisite_Course.__tablename__ in existing_tables
 
 
 def test_insert_and_query(engine):


### PR DESCRIPTION
## What?

This pull request contains the addition of the prerequisite nesting and prerequisite course table models that we've had defined in our Google Doc schema from a while back.

A small but unrelated change also included in this PR is the removal of the keywords field from `pyproject.toml`, which I don't think served any purpose.

This is a remake of closed pull request #10 since I changed the branch name to use a dash instead of underscore.

## Why?

Now that the prerequisite parser in the SIS scraper has been completed, we need these tables to store the data from the parser and to serve it to our API, which can then be used by our website. All for the end goal of helping our (potential) users make more informed course plans.

## How?

Nick and I created some new table models in `models.py`, along with a new enumerator class to support the prerequisite nesting table.

## Testing?

I added the prerequisite tables to the tests. The tests pass.